### PR TITLE
Update for Python 3.8 and lambda-base-2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda-base:build
+FROM lambci/lambda-base-2:build
 
 ARG LEPTONICA_VERSION=1.78.0
 ARG TESSERACT_VERSION=4.1.0-rc4
@@ -41,7 +41,12 @@ RUN mkdir -p ${DIST}/lib && mkdir -p ${DIST}/bin && \
     cp ${TESSERACT}/bin/tesseract ${DIST}/bin/ && \
     cp ${TESSERACT}/lib/libtesseract.so.4  ${DIST}/lib/ && \
     cp ${LEPTONICA}/lib/liblept.so.5 ${DIST}/lib/liblept.so.5 && \
+    cp /usr/lib64/libgomp.so.1 ${DIST}/lib/ && \
     cp /usr/lib64/libwebp.so.4 ${DIST}/lib/ && \
+    cp /usr/lib64/libpng15.so.15 ${DIST}/lib/ && \
+    cp /usr/lib64/libjpeg.so.62 ${DIST}/lib/ && \
+    cp /usr/lib64/libtiff.so.5 ${DIST}/lib/ && \
+    cp /usr/lib64/libjbig.so.2.0 ${DIST}/lib/ && \
     echo -e "LEPTONICA_VERSION=${LEPTONICA_VERSION}\nTESSERACT_VERSION=${TESSERACT_VERSION}\nTESSERACT_DATA_FILES=tessdata${TESSERACT_DATA_SUFFIX}/${TESSERACT_DATA_VERSION}" > ${DIST}/TESSERACT-README.md && \
     find ${DIST}/lib -name '*.so*' | xargs strip -s
 


### PR DESCRIPTION
https://github.com/bweigel/aws-lambda-tesseract-layer/issues/13
https://github.com/keithrozario/Klayers/issues/138

These are the changes I needed to make tesseract compatible with `Klayers-python38-pytesseract` in the AWS lambda layers. It does now work for me.

I know these changes are not backwards compatible at the moment. I'd love your feedback on how to have compatibility between both the `FROM lambci/lambda-base:build` and `lambci/lambda-base-2:build` bases. Happy to collaborate before merging this.

If anyone needs lambda 3.8, you can just clone my fork too.

